### PR TITLE
Allow passing a trusted types policy to the createApi function

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,15 @@ let patch = snabbdom.init([
 
 ### Options
 
-You can also specify a `clean` option to the `createApi` function. This will cause the implementation to create a new, clean Document (untouched by any changes to window globals), and it will use this "clean" document to create elements.
+- `clean`
+  
+  You can specify a `clean` option to the `createApi` function. This will cause the implementation to create a new, clean Document (untouched by any changes to window globals), and it will use this "clean" document to create elements.
+  
+- `trustedTypesPolicy`
+  
+  You can pass a [`TrustedTypePolicy`](https://developer.mozilla.org/en-US/docs/Web/API/TrustedTypePolicy) to the `createApi` function via the `trustedTypesPolicy` option. When the `clean` option is true, this will cause the "clean" document to use that passed policy as the default policy when setting any "injection sinks." See the Trusted Types documentation for more details.
 
-The `createApi` function simply takes a hash of option values:
+To set options simply pass a hash of option values to the `createApi` function:
 
 ```javascript
 import { createApi } from 'snabbdom-iframe-domapi';
@@ -57,9 +63,10 @@ import snabbdomClass from 'snabbdom/modules/class';
 import snabbdomProps from 'snabbdom/modules/props';
 import snabbdomEventListeners from 'snabbdom/modules/eventlisteners';
 
-const domApi = createApi({ clean: true });
+const policy = window.trustedTypes.defaultPolicy;
+const domApi = createApi({ clean: true, trustedTypesPolicy: policy });
 
-let patch = snabbdom.init([
+const patch = snabbdom.init([
     snabbdomClass,
     snabbdomProps,
     snabbdomEventListeners

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "mocha": "^2.4.5",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",
-    "snabbdom": ">0.4.0",
+    "snabbdom": "^0.4.0",
     "webpack": "^1.12.12"
   },
   "peerDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,14 @@ export function createApi(opts) {
         const creationFrame = document.createElement("iframe");
         document.head.appendChild(creationFrame);
         creationDoc = creationFrame.contentDocument;
+        if (opts.trustedTypesPolicy) {
+            creationFrame.contentWindow.trustedTypes.createPolicy('default', {
+              createHTML: (string) =>
+                opts.trustedTypesPolicy.createHTML(string).toString(),
+              createScript: (string) => opts.trustedTypesPolicy.createScript(string).toString(),
+              createScriptURL: (string) => opts.trustedTypesPolicy.createScriptURL(string).toString(),
+            });
+        }
     }
 
     return {

--- a/test/tests/index_test.js
+++ b/test/tests/index_test.js
@@ -15,13 +15,34 @@ describe("snabbdom-iframe-domapi", () => {
         expect(api.setTextContent).to.be.a('function');
     });
 
-    describe("should respect the clean option", () => {
+    it("should respect the clean option", () => {
         const cleanApi = createApi({ clean: true});
         const cleanEl = cleanApi.createElement("div");
         expect(cleanEl.ownerDocument).to.not.equal(document);
 
         const dirtyEl = api.createElement("div");
         expect(dirtyEl.ownerDocument).to.equal(document);
+    });
+
+    it("should use the passed in trusted types policy", () => {
+        const meta = document.createElement('meta');
+        meta.setAttribute('http-equiv','Content-Security-Policy');
+        meta.setAttribute('content', "require-trusted-types-for 'script';");
+        document.head.appendChild(meta);
+
+        const stub = sinon.stub();
+        stub.returnsArg(0);
+
+        const policy = window.trustedTypes.createPolicy('test', {
+          createHTML: stub,
+          createScript: (string) => string,
+          createScriptURL: (string) => string,
+        });
+        const cleanApi = createApi({ clean: true, trustedTypesPolicy: policy });
+        const cleanEl = cleanApi.createElement("div");
+        cleanEl.innerHTML = '<span>test</span>';
+        document.body.appendChild(cleanEl);
+        expect(stub).to.have.been.called;
     });
 
     describe("createElement", () => {

--- a/test/tests/index_test.js
+++ b/test/tests/index_test.js
@@ -24,25 +24,35 @@ describe("snabbdom-iframe-domapi", () => {
         expect(dirtyEl.ownerDocument).to.equal(document);
     });
 
-    it("should use the passed in trusted types policy", () => {
-        const meta = document.createElement('meta');
-        meta.setAttribute('http-equiv','Content-Security-Policy');
-        meta.setAttribute('content', "require-trusted-types-for 'script';");
-        document.head.appendChild(meta);
-
-        const stub = sinon.stub();
-        stub.returnsArg(0);
-
-        const policy = window.trustedTypes.createPolicy('test', {
-          createHTML: stub,
-          createScript: (string) => string,
-          createScriptURL: (string) => string,
+    describe("when there is a trusted types declaration in the CSP", () => {
+        beforeEach(() => {
+            const meta = document.createElement('meta');
+            meta.setAttribute('id', 'csp-meta');
+            meta.setAttribute('http-equiv','Content-Security-Policy');
+            meta.setAttribute('content', "require-trusted-types-for 'script';");
+            document.head.appendChild(meta);
         });
-        const cleanApi = createApi({ clean: true, trustedTypesPolicy: policy });
-        const cleanEl = cleanApi.createElement("div");
-        cleanEl.innerHTML = '<span>test</span>';
-        document.body.appendChild(cleanEl);
-        expect(stub).to.have.been.called;
+
+        afterEach(() => {
+            const meta = document.getElementById('csp-meta');
+            document.head.removeChild(meta);
+        });
+
+        it("should use the passed in trusted types policy", () => {
+            const stub = sinon.stub();
+            stub.returnsArg(0);
+
+            const policy = window.trustedTypes.createPolicy('test', {
+              createHTML: stub,
+              createScript: (string) => string,
+              createScriptURL: (string) => string,
+            });
+            const cleanApi = createApi({ clean: true, trustedTypesPolicy: policy });
+            const cleanEl = cleanApi.createElement("div");
+            cleanEl.innerHTML = '<span>test</span>';
+            document.body.appendChild(cleanEl);
+            expect(stub).to.have.been.called;
+        });
     });
 
     describe("createElement", () => {


### PR DESCRIPTION
In order to properly support [trusted types](https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API) in websites, the iframe that creates "clean" elements must have a default policy. The approach taken here is that a trusted types policy can be passed in as an option to the `createApi` function. This policy will be used to set any "injection sink" values for the elements created by the library. 