### PR TITLE
Handle when the creation doc is removed from the page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snabbdom-iframe-domapi",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "snabbdom-iframe-domapi",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "devDependencies": {
         "babel-cli": "^6.3.17",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snabbdom-iframe-domapi",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "DOM API for Snabbdom with iframe support.",
   "author": {
     "name": "Ray Di Ciaccio",

--- a/src/index.js
+++ b/src/index.js
@@ -1,33 +1,53 @@
 const TEXT_CONTENT = 'textContent';
 
 export function createApi(opts) {
-    let creationDoc = document;
+    let creationDoc;
 
-    if (opts && opts.clean) {
-        const creationFrame = document.createElement("iframe");
-        document.head.appendChild(creationFrame);
-        creationDoc = creationFrame.contentDocument;
-        if (opts.trustedTypesPolicy) {
-            creationFrame.contentWindow.trustedTypes.createPolicy('default', {
-              createHTML: (string) =>
-                opts.trustedTypesPolicy.createHTML(string).toString(),
-              createScript: (string) => opts.trustedTypesPolicy.createScript(string).toString(),
-              createScriptURL: (string) => opts.trustedTypesPolicy.createScriptURL(string).toString(),
-            });
+    function getCreationDoc() {
+        if (creationDoc && creationDoc.defaultView) {
+            return creationDoc;
+        } else if (opts && opts.clean) {
+            const creationFrame = document.createElement("iframe");
+            document.head.appendChild(creationFrame);
+            creationDoc = creationFrame.contentDocument;
+            if (opts.trustedTypesPolicy) {
+                creationFrame.contentWindow.trustedTypes.createPolicy(
+                    "default",
+                    {
+                        createHTML: (string) =>
+                            opts.trustedTypesPolicy
+                                .createHTML(string)
+                                .toString(),
+                        createScript: (string) =>
+                            opts.trustedTypesPolicy
+                                .createScript(string)
+                                .toString(),
+                        createScriptURL: (string) =>
+                            opts.trustedTypesPolicy
+                                .createScriptURL(string)
+                                .toString(),
+                    }
+                );
+            }
+        } else {
+            creationDoc = document;
         }
+        return creationDoc;
     }
+
+    getCreationDoc();
 
     return {
         createElement: function(tagName) {
-            return creationDoc.createElement(tagName);
+            return getCreationDoc().createElement(tagName);
         },
 
         createElementNS: function(namespaceURI, tagName) {
-            return creationDoc.createElementNS(namespaceURI, tagName);
+            return getCreationDoc().createElementNS(namespaceURI, tagName);
         },
 
         createTextNode: function(text) {
-            return creationDoc.createTextNode(text);
+            return getCreationDoc().createTextNode(text);
         },
 
         appendChild: function(parent, child) {

--- a/test/tests/index_test.js
+++ b/test/tests/index_test.js
@@ -24,6 +24,21 @@ describe("snabbdom-iframe-domapi", () => {
         expect(dirtyEl.ownerDocument).to.equal(document);
     });
 
+    it("should handle when the creation doc is removed", () => {
+        const cleanApi = createApi({ clean: true });
+        const cleanEl = cleanApi.createElement("div");
+        expect(cleanEl.ownerDocument).to.not.equal(document);
+
+        const creationFrame = cleanEl.ownerDocument.defaultView.frameElement;
+        creationFrame.parentElement.removeChild(creationFrame);
+
+        const newCleanEl = cleanApi.createElement("div");
+        expect(newCleanEl.ownerDocument).to.not.equal(document);
+        expect(newCleanEl.ownerDocument).to.not.equal(cleanEl.ownerDocument);
+        expect(newCleanEl.ownerDocument.defaultView).to.not.equal(null);
+        expect(cleanEl.ownerDocument.defaultView).to.equal(null);
+    });
+
     describe("when there is a trusted types declaration in the CSP", () => {
         beforeEach(() => {
             const meta = document.createElement('meta');


### PR DESCRIPTION
Some sites will remove the `iframe` containing the `document` that this library uses to create elements when in "clean" mode. This causes inconsistent behavior in some cases. For example, iframes created with the "detached" document will not fire the "load" event. 

This PR introduces a change to re-create the document if we detect that it has been removed from the page. The way we're able to detect removal is if the document has no `defaultView`. When this is the case, we create a new iframe and append it to the body in order to get a clean document for element creation.

This also adds the `hidden` attribute to the iframe to help keep it from displaying on the page.