### PR TITLE
implement new methods needed to support snabbdom 3 and experimental fragments support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snabbdom-iframe-domapi",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "snabbdom-iframe-domapi",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "babel-cli": "^6.3.17",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snabbdom-iframe-domapi",
-  "version": "0.4.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "snabbdom-iframe-domapi",
-      "version": "0.4.0",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "babel-cli": "^6.3.17",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snabbdom-iframe-domapi",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "DOM API for Snabbdom with iframe support.",
   "author": {
     "name": "Ray Di Ciaccio",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snabbdom-iframe-domapi",
-  "version": "0.4.0",
+  "version": "1.0.0",
   "description": "DOM API for Snabbdom with iframe support.",
   "author": {
     "name": "Ray Di Ciaccio",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,22 @@
 const TEXT_CONTENT = 'textContent';
 
+function parseFragment(
+    fragmentNode,
+    parentNode
+) {
+    const fragment = fragmentNode;
+    if(fragment.parent == null) {
+        fragment.parent = parentNode || null;
+    }
+    if(fragment.firstChildNode == null) {
+        fragment.firstChildNode = fragmentNode.firstChild;
+    }
+    if(fragment.lastChildNode == null) {
+        fragment.lastChildNode = fragmentNode.lastChild;
+    }
+    return fragment;
+}
+
 export function createApi(opts) {
     let creationDoc;
 
@@ -76,7 +93,28 @@ export function createApi(opts) {
 
         setTextContent: function(node, text) {
             dom(TEXT_CONTENT, node, text);
-        }
+        },
+        isElement: function isElement(node) {
+            return node.nodeType === 1;
+        },
+        isText: function isText(node) {
+            return node.nodeType === 3;
+        },
+        isComment: function isComment(node) {
+            return node.nodeType === 8;
+        },
+        isDocumentFragment: function isDocumentFragment(node) {
+            return node.nodeType === 11;
+        },
+        createDocumentFragment: function createDocumentFragment() {
+            return parseFragment(getCreationDoc().createDocumentFragment());
+        },
+        createComment: function createComment(text) {
+            return getCreationDoc().createComment(text);
+        },
+        getTextContent: function getTextContent(node) {
+            return node.textContent || null;
+        },
     };
 }
 


### PR DESCRIPTION
This changes were based on https://github.com/snabbdom/snabbdom/blob/b03ed27d149ba31f665a2fe041cb7c7bcf4233b0/src/htmldomapi.ts#L7 interface, god bless TS!

without this updating to snabbdom 3 breaks SDK's rendering as it requires a couple of the new methods, like isElement